### PR TITLE
Устойчивость к обрывам: liveness сессий, route guard, автопереподключение

### DIFF
--- a/backend/orchestrator.go
+++ b/backend/orchestrator.go
@@ -10,6 +10,7 @@ import (
 	"path/filepath"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/wailsapp/wails/v2/pkg/runtime"
@@ -180,6 +181,11 @@ type ConnectParams struct {
 
 	// ExcludeDomains — паттерны доменов для исключения из туннеля (wildcards поддерживаются).
 	ExcludeDomains []string `json:"excludeDomains,omitempty"`
+
+	// AutoReconnect — если ядро завершилось само (не по кнопке «Отключить»
+	// и не из-за фатальной ошибки авторизации), поднять сессию заново с
+	// экспоненциальной задержкой. Фронт передаёт значение из настроек.
+	AutoReconnect bool `json:"autoReconnect,omitempty"`
 }
 
 func loadProfile(name string) (*ProfileData, error) {
@@ -199,6 +205,13 @@ type coreSession struct {
 	c      *core.Core
 	doneCh <-chan core.Event // закрывается когда core завершился
 	done   chan struct{}    // закрывается когда forwardEvents полностью вышел (включая WG-teardown)
+
+	params      ConnectParams // для автопереподключения
+	isReconnect bool          // сессия поднята автопереподключением
+	userStop    atomic.Bool   // остановлена пользователем (Disconnect/выход)
+	fatal       atomic.Bool   // фатальная ошибка авторизации — не переподключаемся
+	wasUp       atomic.Bool   // туннель хотя бы раз дошёл до wg_up
+	upAt        atomic.Int64  // unix-время wg_up (для сброса backoff)
 }
 
 // connectionStep — этапы подключения, отслеживаемые pipeline.
@@ -229,15 +242,32 @@ type pipelineState struct {
 }
 
 // pipelineController следит за этапами подключения и останавливает туннель при ошибках/таймаутах.
+//
+// Важно: контроллер описывает ТОЛЬКО начальное подключение. После finish()
+// (wg_up) он становится инертным. Раньше любое событие dtls_error /
+// wrap_auth_timeout от любого воркера — в том числе при обычном
+// переподключении воркера после обрыва сети — вызывало markFailed → Stop()
+// и сносило работающий туннель целиком. Плюс каждый turn_allocated
+// повторно взводил 12-секундный таймер этапа DTLS.
 type pipelineController struct {
-	ctx       context.Context
-	cancel    context.CancelFunc
-	mu        sync.Mutex
-	state     pipelineState
-	sess      *coreSession
-	stopFunc  func()
-	timer     *time.Timer
+	ctx      context.Context
+	cancel   context.CancelFunc
+	mu       sync.Mutex
+	state    pipelineState
+	sess     *coreSession
+	stopFunc func()
+	timer    *time.Timer
+
+	done         bool // wg_up получен — этапы больше не отслеживаем
+	dtlsOK       bool // хотя бы один воркер прошёл DTLS
+	dtlsFailures int  // провалов DTLS до первого успеха
 }
+
+// dtlsFailuresBeforeFatal — сколько провалов DTLS-хендшейка (до первого
+// успешного) считаем признаком неверного пароля/недоступного сервера.
+// Один провал может быть транзиентным (потеря UDP), два подряд при
+// одновременных попытках нескольких воркеров — уже вряд ли.
+const dtlsFailuresBeforeFatal = 2
 
 func newPipelineController(stopFunc func()) *pipelineController {
 	ctx, cancel := context.WithCancel(context.Background())
@@ -257,41 +287,63 @@ func (pc *pipelineController) emitState(appCtx context.Context) {
 	runtime.EventsEmit(appCtx, "pipeline_state", pc.state)
 }
 
+func (pc *pipelineController) isCompletedLocked(step connectionStep) bool {
+	for _, c := range pc.state.Completed {
+		if c == string(step) {
+			return true
+		}
+	}
+	return false
+}
+
+// setCurrent переводит схему на этап step. Этапы двигаются только вперёд:
+// повторные события от следующих воркеров (turn_allocated, dtls_ok…) не
+// откатывают схему назад и не перевзводят таймер.
 func (pc *pipelineController) setCurrent(appCtx context.Context, step connectionStep) {
 	pc.mu.Lock()
-	if pc.state.Failed != nil {
+	if pc.state.Failed != nil || pc.done || pc.isCompletedLocked(step) || pc.state.Current == step {
 		pc.mu.Unlock()
 		return
 	}
 	pc.state.Current = step
 	pc.state.TimedOut = false
+	pc.armTimeoutLocked(appCtx, step)
 	pc.mu.Unlock()
-	pc.armTimeout(appCtx, step)
 	pc.emitState(appCtx)
 }
 
 func (pc *pipelineController) markCompleted(appCtx context.Context, step connectionStep) {
 	pc.mu.Lock()
-	if pc.state.Failed != nil {
+	if pc.state.Failed != nil || pc.done || pc.isCompletedLocked(step) {
 		pc.mu.Unlock()
 		return
 	}
-	found := false
-	for _, c := range pc.state.Completed {
-		if c == string(step) {
-			found = true
-			break
-		}
-	}
-	if !found {
-		pc.state.Completed = append(pc.state.Completed, string(step))
-	}
+	pc.state.Completed = append(pc.state.Completed, string(step))
 	pc.mu.Unlock()
 	pc.emitState(appCtx)
 }
 
+// markFailed фиксирует ошибку начального подключения и останавливает сессию.
+// После finish() — no-op (кроме фатальной авторизации, см. markFatal).
 func (pc *pipelineController) markFailed(appCtx context.Context, step connectionStep, timedOut bool, timeoutSec int, reason string) {
 	pc.mu.Lock()
+	if pc.done {
+		pc.mu.Unlock()
+		return
+	}
+	pc.failLocked(appCtx, step, timedOut, timeoutSec, reason)
+}
+
+// markFatal — ошибка авторизации (неверный/истёкший пароль): останавливаем
+// даже работающий туннель, переподключаться бессмысленно.
+func (pc *pipelineController) markFatal(appCtx context.Context, reason string) {
+	pc.mu.Lock()
+	pc.failLocked(appCtx, stepDTLS, false, 0, reason)
+}
+
+// failLocked — общая часть markFailed/markFatal. Вызывается с захваченным pc.mu
+// и освобождает его сам.
+func (pc *pipelineController) failLocked(appCtx context.Context, step connectionStep, timedOut bool, timeoutSec int, reason string) {
 	if pc.state.Failed != nil {
 		pc.mu.Unlock()
 		return
@@ -301,26 +353,48 @@ func (pc *pipelineController) markFailed(appCtx context.Context, step connection
 	pc.state.TimedOut = timedOut
 	pc.state.TimeoutSec = timeoutSec
 	pc.state.Current = step
+	pc.stopTimerLocked()
 	pc.mu.Unlock()
-	if pc.timer != nil {
-		pc.timer.Stop()
-		pc.timer = nil
-	}
 	pc.emitState(appCtx)
 	runtime.EventsEmit(appCtx, "log", "ERROR", fmt.Sprintf("[СХЕМА] Ошибка на этапе %s: %s", step, reason))
 	go pc.stopFunc()
 }
 
+// onDTLSResult учитывает результат DTLS-хендшейка воркера. Возвращает true,
+// если провал нужно считать фатальным для начального подключения.
+func (pc *pipelineController) onDTLSResult(ok bool) (fatal bool) {
+	pc.mu.Lock()
+	defer pc.mu.Unlock()
+	if ok {
+		pc.dtlsOK = true
+		return false
+	}
+	if pc.done || pc.dtlsOK {
+		return false
+	}
+	pc.dtlsFailures++
+	return pc.dtlsFailures >= dtlsFailuresBeforeFatal
+}
+
 func (pc *pipelineController) finish(appCtx context.Context) {
 	pc.mu.Lock()
+	if pc.done {
+		pc.mu.Unlock()
+		return
+	}
+	pc.done = true
 	pc.state.Current = stepDone
 	pc.state.Completed = append(pc.state.Completed, string(stepDone))
+	pc.stopTimerLocked()
 	pc.mu.Unlock()
+	pc.emitState(appCtx)
+}
+
+func (pc *pipelineController) stopTimerLocked() {
 	if pc.timer != nil {
 		pc.timer.Stop()
 		pc.timer = nil
 	}
-	pc.emitState(appCtx)
 }
 
 func (pc *pipelineController) hide() {
@@ -329,18 +403,21 @@ func (pc *pipelineController) hide() {
 	pc.mu.Unlock()
 }
 
-func (pc *pipelineController) armTimeout(appCtx context.Context, step connectionStep) {
-	if pc.timer != nil {
-		pc.timer.Stop()
-		pc.timer = nil
-	}
+// armTimeoutLocked взводит таймер этапа. Вызывается с захваченным pc.mu.
+func (pc *pipelineController) armTimeoutLocked(appCtx context.Context, step connectionStep) {
+	pc.stopTimerLocked()
 	// Workers и captcha могут ждать пользователя; WG — зависит от системы.
 	if step == stepWorkers || step == stepCaptcha || step == stepWG {
 		return
 	}
 	timeout := 12 * time.Second
-	if step == stepVK {
+	switch step {
+	case stepVK:
 		timeout = 30 * time.Second
+	case stepTurn, stepDTLS:
+		// TURN allocate + DTLS через relay: 3 параллельных хендшейка по 20с
+		// плюс retry воркеров. 12с было мало на медленных/лоссовых каналах.
+		timeout = 40 * time.Second
 	}
 	pc.timer = time.AfterFunc(timeout, func() {
 		pc.markFailed(appCtx, step, true, int(timeout.Seconds()), "таймаут этапа")
@@ -349,10 +426,9 @@ func (pc *pipelineController) armTimeout(appCtx context.Context, step connection
 
 func (pc *pipelineController) close() {
 	pc.cancel()
-	if pc.timer != nil {
-		pc.timer.Stop()
-		pc.timer = nil
-	}
+	pc.mu.Lock()
+	pc.stopTimerLocked()
+	pc.mu.Unlock()
 }
 
 // Orchestrator — тонкий прокси между Wails UI и core.Core.
@@ -363,14 +439,36 @@ type Orchestrator struct {
 	prevLogWriter io.Writer
 	onTray        func(connected bool, rx, tx int64, workers int32)
 	pipeline      *pipelineController
+
+	// Автопереподключение.
+	reconnectTimer   *time.Timer
+	reconnectPending bool
+	reconnectAttempt int
 }
+
+// Параметры backoff автопереподключения.
+const (
+	reconnectMinDelay = 3 * time.Second
+	reconnectMaxDelay = 60 * time.Second
+	// Если туннель продержался дольше — считаем предыдущие попытки
+	// «успешными» и начинаем backoff заново.
+	reconnectStableAfter = 2 * time.Minute
+)
 
 func NewOrchestrator(ctx context.Context, onTray func(bool, int64, int64, int32)) *Orchestrator {
 	return &Orchestrator{appCtx: ctx, onTray: onTray}
 }
 
-// Start запускает сессию. Возвращает ошибку, если уже запущена.
+// Start запускает сессию по кнопке пользователя. Возвращает ошибку, если уже запущена.
 func (o *Orchestrator) Start(p ConnectParams) error {
+	o.cancelReconnect()
+	o.mu.Lock()
+	o.reconnectAttempt = 0
+	o.mu.Unlock()
+	return o.start(p, false)
+}
+
+func (o *Orchestrator) start(p ConnectParams, isReconnect bool) error {
 	o.mu.Lock()
 	if o.sess != nil {
 		o.mu.Unlock()
@@ -380,7 +478,7 @@ func (o *Orchestrator) Start(p ConnectParams) error {
 	o.sess = placeholder
 	o.mu.Unlock()
 
-	sess, err := o.launch(p)
+	sess, err := o.launch(p, isReconnect)
 	if err != nil {
 		o.mu.Lock()
 		if o.sess == placeholder {
@@ -396,7 +494,7 @@ func (o *Orchestrator) Start(p ConnectParams) error {
 	return nil
 }
 
-func (o *Orchestrator) launch(p ConnectParams) (*coreSession, error) {
+func (o *Orchestrator) launch(p ConnectParams, isReconnect bool) (*coreSession, error) {
 	// Перехватываем стандартный логгер → Wails события
 	if _, already := log.Writer().(*wailsLogWriter); !already {
 		o.prevLogWriter = log.Writer()
@@ -496,9 +594,11 @@ func (o *Orchestrator) launch(p ConnectParams) (*coreSession, error) {
 		return nil, fmt.Errorf("core start: %w", err)
 	}
 
-	sess := &coreSession{c: c, doneCh: events, done: make(chan struct{})}
+	sess := &coreSession{c: c, doneCh: events, done: make(chan struct{}), params: p, isReconnect: isReconnect}
 	o.mu.Lock()
-	o.pipeline = newPipelineController(func() { o.Stop() })
+	// Остановка по ошибке схемы — не «по кнопке»: для reconnect-сессий
+	// она приведёт к следующей попытке с backoff.
+	o.pipeline = newPipelineController(func() { o.stopSession(sess, false) })
 	o.mu.Unlock()
 	go o.forwardEvents(sess)
 	// Polling-цикл статистики для tray-иконки.
@@ -558,7 +658,15 @@ func (o *Orchestrator) forwardEvents(sess *coreSession) {
 				runtime.EventsEmit(o.appCtx, "vk_auth_required", ev.Data)
 			}
 			if ev.Name == "fatal_auth" {
+				sess.fatal.Store(true)
 				runtime.EventsEmit(o.appCtx, "error", ev.Data)
+			}
+			if ev.Name == "wg_up" {
+				sess.wasUp.Store(true)
+				sess.upAt.Store(time.Now().Unix())
+				if sess.isReconnect {
+					runtime.EventsEmit(o.appCtx, "log", "INFO", "[RECONNECT] Туннель восстановлен ✓")
+				}
 			}
 			runtime.EventsEmit(o.appCtx, "event", ev.Name, ev.Data)
 		}
@@ -590,7 +698,88 @@ func (o *Orchestrator) forwardEvents(sess *coreSession) {
 		o.pipeline = nil
 	}
 	o.mu.Unlock()
+
+	if o.scheduleReconnect(sess) {
+		return
+	}
 	runtime.EventsEmit(o.appCtx, "state_changed", "disconnected", "")
+}
+
+// scheduleReconnect решает, нужно ли поднимать сессию заново, и если да —
+// взводит таймер. Возвращает true, если переподключение запланировано.
+//
+// Переподключаемся, если:
+//   - включено в настройках (params.AutoReconnect);
+//   - сессию не останавливал пользователь;
+//   - не было фатальной ошибки авторизации;
+//   - туннель хотя бы раз был поднят ИЛИ это уже reconnect-сессия
+//     (иначе ошибка первого подключения показывается пользователю как раньше).
+func (o *Orchestrator) scheduleReconnect(sess *coreSession) bool {
+	if !sess.params.AutoReconnect || sess.userStop.Load() || sess.fatal.Load() {
+		return false
+	}
+	if !sess.wasUp.Load() && !sess.isReconnect {
+		return false
+	}
+
+	o.mu.Lock()
+	if sess.wasUp.Load() && time.Since(time.Unix(sess.upAt.Load(), 0)) > reconnectStableAfter {
+		o.reconnectAttempt = 0
+	}
+	attempt := o.reconnectAttempt
+	o.reconnectAttempt++
+	delay := reconnectMaxDelay
+	if attempt < 8 {
+		delay = reconnectMinDelay << uint(attempt)
+		if delay > reconnectMaxDelay {
+			delay = reconnectMaxDelay
+		}
+	}
+	o.reconnectPending = true
+	params := sess.params
+	o.reconnectTimer = time.AfterFunc(delay, func() { o.doReconnect(params) })
+	o.mu.Unlock()
+
+	runtime.EventsEmit(o.appCtx, "log", "WARN", fmt.Sprintf("[RECONNECT] Туннель упал, переподключение через %v (попытка %d)", delay, attempt+1))
+	runtime.EventsEmit(o.appCtx, "state_changed", "reconnecting", "")
+	return true
+}
+
+func (o *Orchestrator) doReconnect(params ConnectParams) {
+	o.mu.Lock()
+	if !o.reconnectPending {
+		o.mu.Unlock()
+		return
+	}
+	o.reconnectPending = false
+	o.reconnectTimer = nil
+	o.mu.Unlock()
+
+	runtime.EventsEmit(o.appCtx, "log", "INFO", "[RECONNECT] Переподключение...")
+	if err := o.start(params, true); err != nil {
+		runtime.EventsEmit(o.appCtx, "log", "ERROR", fmt.Sprintf("[RECONNECT] Не удалось запустить: %v", err))
+		// Поднять не удалось (порт занят, профиль пропал…) — планируем ещё раз.
+		fake := &coreSession{params: params, isReconnect: true}
+		if !o.scheduleReconnect(fake) {
+			runtime.EventsEmit(o.appCtx, "state_changed", "disconnected", "")
+		}
+	}
+}
+
+// cancelReconnect отменяет запланированное переподключение (если есть).
+// Возвращает true, если оно было запланировано.
+func (o *Orchestrator) cancelReconnect() bool {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	if !o.reconnectPending {
+		return false
+	}
+	o.reconnectPending = false
+	if o.reconnectTimer != nil {
+		o.reconnectTimer.Stop()
+		o.reconnectTimer = nil
+	}
+	return true
 }
 
 func (o *Orchestrator) handlePipelineEvent(ev core.Event) {
@@ -615,6 +804,7 @@ func (o *Orchestrator) handlePipelineEvent(ev core.Event) {
 		pc.markCompleted(o.appCtx, stepTurn)
 		pc.setCurrent(o.appCtx, stepDTLS)
 	case "dtls_ok":
+		pc.onDTLSResult(true)
 		pc.markCompleted(o.appCtx, stepDTLS)
 		pc.setCurrent(o.appCtx, stepWorkers)
 	case "worker_ready":
@@ -623,16 +813,24 @@ func (o *Orchestrator) handlePipelineEvent(ev core.Event) {
 	case "wg_up":
 		pc.markCompleted(o.appCtx, stepWG)
 		pc.finish(o.appCtx)
-		case "wrap_auth_timeout":
-			reason := "WRAP/DTLS не подтверждён: неверный пароль, сервер недоступен или UDP режет оператор"
+	case "wrap_auth_timeout":
+		reason := "WRAP/DTLS не подтверждён: неверный пароль, сервер недоступен или UDP режет оператор"
+		if pc.onDTLSResult(false) {
 			runtime.EventsEmit(o.appCtx, "log", "ERROR", "[СХЕМА] Ошибка DTLS: "+reason)
 			pc.markFailed(o.appCtx, stepDTLS, false, 0, reason)
-		case "dtls_error":
+		} else {
+			runtime.EventsEmit(o.appCtx, "log", "WARN", "[DTLS] Таймаут хендшейка воркера, повторим ("+ev.Data+")")
+		}
+	case "dtls_error":
+		if pc.onDTLSResult(false) {
 			runtime.EventsEmit(o.appCtx, "log", "ERROR", "[СХЕМА] Ошибка DTLS: "+ev.Data)
 			pc.markFailed(o.appCtx, stepDTLS, false, 0, ev.Data)
-		case "fatal_auth":
-			runtime.EventsEmit(o.appCtx, "log", "ERROR", "[СХЕМА] Ошибка авторизации: "+ev.Data)
-			pc.markFailed(o.appCtx, stepDTLS, false, 0, ev.Data)
+		} else {
+			runtime.EventsEmit(o.appCtx, "log", "WARN", "[DTLS] Ошибка хендшейка воркера, повторим ("+ev.Data+")")
+		}
+	case "fatal_auth":
+		runtime.EventsEmit(o.appCtx, "log", "ERROR", "[СХЕМА] Ошибка авторизации: "+ev.Data)
+		pc.markFatal(o.appCtx, ev.Data)
 	}
 }
 
@@ -641,11 +839,28 @@ func (o *Orchestrator) handlePipelineEvent(ev core.Event) {
 // потому что o.sess обнуляется только в forwardEvents после WG-teardown,
 // а это занимает 5-15 секунд.
 func (o *Orchestrator) Stop() {
+	// Пользователь нажал «Отключить»: отменяем ожидающее переподключение.
+	if o.cancelReconnect() {
+		runtime.EventsEmit(o.appCtx, "log", "INFO", "[RECONNECT] Автопереподключение отменено")
+		runtime.EventsEmit(o.appCtx, "state_changed", "disconnected", "")
+	}
 	o.mu.Lock()
 	sess := o.sess
 	o.mu.Unlock()
 	if sess == nil || sess.c == nil {
 		return
+	}
+	o.stopSession(sess, true)
+}
+
+// stopSession останавливает конкретную сессию. userInitiated=true помечает
+// её как остановленную пользователем (автопереподключения не будет).
+func (o *Orchestrator) stopSession(sess *coreSession, userInitiated bool) {
+	if sess == nil || sess.c == nil {
+		return
+	}
+	if userInitiated {
+		sess.userStop.Store(true)
 	}
 	sess.c.Stop()
 	if sess.done != nil {
@@ -702,9 +917,10 @@ func (o *Orchestrator) Resume() {
 	sess.c.Resume()
 }
 
+// IsRunning — есть ли активная сессия или ожидающее автопереподключение.
 func (o *Orchestrator) IsRunning() bool {
 	o.mu.Lock()
 	defer o.mu.Unlock()
-	return o.sess != nil && o.sess.c != nil
+	return (o.sess != nil && o.sess.c != nil) || o.reconnectPending
 }
 

--- a/client/core/core.go
+++ b/client/core/core.go
@@ -79,6 +79,13 @@ type Core struct {
 	wgCacheAt       time.Time
 	wgCacheKey      string
 
+	// eventsMu защищает закрытие c.events: emit() после close() = паника
+	// "send on closed channel". Раньше это могло случиться, когда ядро
+	// завершалось само (все воркеры вышли), а какая-нибудь горутина
+	// (VK creds / WebView / TURN payload) ещё дёргала глобальный эмиттер.
+	eventsMu     sync.RWMutex
+	eventsClosed bool
+
 	once sync.Once
 }
 
@@ -160,7 +167,7 @@ func (c *Core) Start(ctx context.Context) (<-chan Event, error) {
 	ctx = c.ctx
 
 	// Регистрируем глобальный эмиттер для captcha_required и т.п.
-	EmitEvent = c.emit
+	SetEmitEvent(c.emit)
 
 	peer, err := net.ResolveUDPAddr("udp", c.cfg.PeerAddr)
 	if err != nil {
@@ -409,7 +416,7 @@ func (c *Core) Start(ctx context.Context) (<-chan Event, error) {
 	}
 
 	go func() {
-		defer close(c.events)
+		defer c.closeEvents()
 		defer c.cancel()
 		defer func() { _ = localConn.Close() }()
 		defer disp.Shutdown()
@@ -430,7 +437,7 @@ func (c *Core) Stop() {
 		if c.cancel != nil {
 			c.cancel()
 		}
-		EmitEvent = nil
+		SetEmitEvent(nil)
 		WebViewCaptchaHandler = nil
 	})
 }
@@ -501,7 +508,23 @@ func (c *Core) Stats() Snapshot {
 	}
 }
 
+// closeEvents закрывает канал событий ровно один раз и блокирует дальнейшие emit.
+func (c *Core) closeEvents() {
+	c.eventsMu.Lock()
+	defer c.eventsMu.Unlock()
+	if c.eventsClosed {
+		return
+	}
+	c.eventsClosed = true
+	close(c.events)
+}
+
 func (c *Core) emit(ev Event) {
+	c.eventsMu.RLock()
+	defer c.eventsMu.RUnlock()
+	if c.eventsClosed {
+		return
+	}
 	select {
 	case c.events <- ev:
 	default:

--- a/client/core/creds.go
+++ b/client/core/creds.go
@@ -792,13 +792,11 @@ func requestWebViewCaptcha(streamID int, captchaErr *VkCaptchaError, mode string
 	fmt.Printf("CAPTCHA_SOLVE|%s|%s|%s\n", mode, captchaErr.RedirectURI, captchaErr.SessionToken)
 
 	// Emit captcha_required для внешнего решателя (frontend/Android)
-	if EmitEvent != nil {
-		EmitEvent(Event{
+			emitEvent(Event{
 			Type: EventEvent,
 			Name: "captcha_required",
 			Data: fmt.Sprintf("%s|%s|%s", mode, captchaErr.RedirectURI, captchaErr.SessionToken),
 		})
-	}
 
 	waitCtx, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()

--- a/client/core/domain_exclude.go
+++ b/client/core/domain_exclude.go
@@ -142,6 +142,32 @@ func newDomainExcluder(patterns []string, gateway, iface string, dnsServers []st
 	}
 }
 
+// SetGateway переставляет все добавленные /32 маршруты на новый шлюз.
+// Вызывается route guard'ом при смене сети.
+func (de *domainExcluder) SetGateway(gateway, iface string) {
+	de.mu.Lock()
+	defer de.mu.Unlock()
+	if de.gateway == gateway && de.iface == iface {
+		return
+	}
+	de.gateway, de.iface = gateway, iface
+	if gateway == "" {
+		return
+	}
+	moved := 0
+	for ipStr := range de.routeToPattern {
+		runRouteDelete(ipStr + "/32")
+		if runRouteAdd(ipStr+"/32", gateway) {
+			moved++
+		} else {
+			delete(de.routeToPattern, ipStr)
+		}
+	}
+	if moved > 0 {
+		log.Printf("[DOMEXCL] Маршруты переставлены на шлюз %s (%s): %d", gateway, iface, moved)
+	}
+}
+
 // Start запускает периодический refresh (каждые 5 минут) для точных доменов.
 // Wildcard-паттерны обрабатываются on-demand при DNS-запросах.
 func (de *domainExcluder) Start() {

--- a/client/core/group.go
+++ b/client/core/group.go
@@ -107,17 +107,10 @@ func WorkerGroup(
 	}
 
 	// Регистрируем TURN IP-адреса для исключения из WG-маршрутизации
-	for _, url := range creds.TurnURLs {
-		host, _, err := net.SplitHostPort(strings.TrimPrefix(url, "turn://"))
-		if err == nil && host != "" {
-			AddTurnExcludeIP(host)
-		}
-	}
+	registerTurnExcludes(creds.TurnURLs)
 
 	log.Printf("[ГРУППА #%d] Креды OK, TURN: %v, %d воркеров", groupID, creds.TurnURLs, len(workerIDs))
-	if EmitEvent != nil {
-		EmitEvent(Event{Type: EventEvent, Name: "vk_creds_ok", Data: fmt.Sprintf("group=%d urls=%d", groupID, len(creds.TurnURLs))})
-	}
+			emitEvent(Event{Type: EventEvent, Name: "vk_creds_ok", Data: fmt.Sprintf("group=%d urls=%d", groupID, len(creds.TurnURLs))})
 
 	var configRequestInFlight int32
 	var wg sync.WaitGroup
@@ -153,6 +146,9 @@ func WorkerGroup(
 		creds = &Credentials{User: u, Pass: p, TurnURLs: urls, CacheStreamID: credStreamID}
 		credsMu.Unlock()
 		lastCredRefresh.Store(time.Now().Unix())
+		// Новые креды могут прийти с другими TURN-серверами — их тоже нужно
+		// вывести из-под WG-маршрута, иначе трафик воркера зациклится в туннеле.
+		registerTurnExcludes(urls)
 		log.Printf("[TURN] Креды обновлены после %s, TURN urls=%d", reason, len(urls))
 		return true
 	}
@@ -210,15 +206,29 @@ func WorkerGroup(
 				credsSnapshot.TurnURLs = cloneStringSlice(creds.TurnURLs)
 				credsMu.RUnlock()
 
-				configDelivered, sessErr := RunSession(ctx, tp, peer, d, localPort,
-					getConf, cc, wid, &credsSnapshot, deviceID, password, stats)
-
+				// Результат GETCONF приходит колбэком сразу после попытки, а не
+				// после смерти сессии — иначе неудачный запрос блокировал бы
+				// конфиг на всё время жизни сессии.
+				var onConfigAttempt func(bool)
 				if getConf {
-					if configDelivered {
-						atomic.StoreInt32(&configSent, 1)
-					} else {
-						atomic.StoreInt32(&configRequestInFlight, 0)
+					onConfigAttempt = func(delivered bool) {
+						if delivered {
+							atomic.StoreInt32(&configSent, 1)
+						} else {
+							atomic.StoreInt32(&configRequestInFlight, 0)
+						}
 					}
+				}
+
+				sessStart := time.Now()
+				_, sessErr := RunSession(ctx, tp, peer, d, localPort,
+					getConf, cc, wid, &credsSnapshot, deviceID, password, stats, onConfigAttempt)
+
+				// Сессия прожила достаточно долго → это был не «неудачный
+				// коннект», а нормальная работа с последующим обрывом.
+				// Сбрасываем backoff, чтобы переподключение было быстрым.
+				if time.Since(sessStart) > 60*time.Second {
+					attempt = 0
 				}
 
 				if sessErr != nil {
@@ -263,14 +273,11 @@ func WorkerGroup(
 						log.Printf("[ВОРКЕР #%d] Ошибка (попытка %d): %s", wid, attempt, errStr)
 					}
 
-					// Если ошибка STUN (credentials invalid), воркер не сможет переподключиться. Завершаем.
-					isStunDeath := strings.Contains(errStrLower, "error 29") ||
-						strings.Contains(errStrLower, "cannot create socket")
-
-					if isStunDeath {
-						log.Printf("[ВОРКЕР #%d] Невосстановимая TURN/STUN ошибка, завершение: %s", wid, errStr)
-						return
-					}
+					// Раньше «error 29» / «cannot create socket» считались
+					// невосстановимыми и воркер выходил навсегда. На практике
+					// это временные состояния (сеть ещё не поднялась после сна,
+					// VK-флуд-контроль), после которых воркер должен вернуться.
+					// Оставляем воркер в retry-цикле с обычным backoff.
 				}
 
 				if ctx.Err() != nil {
@@ -279,8 +286,12 @@ func WorkerGroup(
 
 				// Exponential backoff с jitter — предотвращает thundering herd,
 				// когда у VK hiccup и все 9 воркеров ретраят одновременно.
-				// 1: 2-5s, 2: 4-7s, 3: 8-11s, 4: 16-19s, 5+: 30-33s.
-				base := 2 << uint(attempt-1)
+				// 0: 1-3s (сессия умерла после долгой работы — переподключаемся
+				// быстро), 1: 2-5s, 2: 4-7s, 3: 8-11s, 4: 16-19s, 5+: 30-33s.
+				base := 1
+				if attempt > 0 {
+					base = 2 << uint(attempt-1)
+				}
 				if base > 30 {
 					base = 30
 				}
@@ -296,6 +307,37 @@ func WorkerGroup(
 
 	wg.Wait()
 	log.Printf("[ГРУППА #%d] Все воркеры группы завершились.", groupID)
+}
+
+// turnURLHost извлекает хост из TURN URL вида "turn:1.2.3.4:443",
+// "turns:host:5349?transport=udp", "turn://…". Возвращает "" если не разобрать.
+func turnURLHost(u string) string {
+	u = strings.TrimSpace(u)
+	for _, prefix := range []string{"turns://", "turn://", "turns:", "turn:"} {
+		if strings.HasPrefix(strings.ToLower(u), prefix) {
+			u = u[len(prefix):]
+			break
+		}
+	}
+	if idx := strings.IndexAny(u, "?#"); idx >= 0 {
+		u = u[:idx]
+	}
+	if host, _, err := net.SplitHostPort(u); err == nil {
+		return host
+	}
+	return u
+}
+
+// registerTurnExcludes выводит хосты TURN-серверов из-под WG-маршрута.
+// Старая версия делала TrimPrefix("turn://") на URL вида "turn:IP:PORT" и
+// SplitHostPort всегда падал с «too many colons» — исключения не добавлялись
+// вообще, спасали только широкие VK CIDR.
+func registerTurnExcludes(urls []string) {
+	for _, u := range urls {
+		if host := turnURLHost(u); host != "" {
+			AddTurnExcludeIP(host)
+		}
+	}
 }
 
 // ParseHashes — парсит строку хешей

--- a/client/core/protocol.go
+++ b/client/core/protocol.go
@@ -18,13 +18,27 @@ func RequestConfig(conn net.Conn, localPort, deviceID, password string) (string,
 	if err := conn.SetReadDeadline(time.Now().Add(8 * time.Second)); err != nil {
 		return "", fmt.Errorf("установка дедлайна: %w", err)
 	}
-	n, err := conn.Read(b)
+	var (
+		n    int
+		err  error
+		resp string
+	)
+	// Пропускаем keepalive-pong (одиночный 0xFF), если он пришёл раньше ответа.
+	for {
+		n, err = conn.Read(b)
+		if err != nil {
+			break
+		}
+		if n == 1 && b[0] == keepaliveByte {
+			continue
+		}
+		resp = string(b[:n])
+		break
+	}
 	_ = conn.SetReadDeadline(time.Time{})
 	if err != nil {
 		return "", fmt.Errorf("чтение ответа конфига: %w", err)
 	}
-
-	resp := string(b[:n])
 	if resp == "NOCONF" {
 		return "", nil
 	}
@@ -42,9 +56,7 @@ func RequestConfig(conn net.Conn, localPort, deviceID, password string) (string,
 		default:
 			authErr = fmt.Errorf("FATAL_AUTH: доступ запрещён (%s)", reason)
 		}
-		if EmitEvent != nil {
-			EmitEvent(Event{Type: EventEvent, Name: "fatal_auth", Data: authErr.Error()})
-		}
+					emitEvent(Event{Type: EventEvent, Name: "fatal_auth", Data: authErr.Error()})
 		return "", authErr
 	}
 

--- a/client/core/session.go
+++ b/client/core/session.go
@@ -24,8 +24,23 @@ const (
 	readBufSize        = 1600
 	socketBufSize      = 625 * 1024
 	keepaliveByte      = 0xFF // DTLS-level keepalive marker
-	keepaliveInterval  = 15 * time.Second
+	keepaliveInterval  = 10 * time.Second
 	dtlsHandshakeTimeout = 20 * time.Second // медленный WG успеет договориться
+
+	// sessionDeadAfter — если за это время через DTLS не пришло НИ ОДНОГО
+	// пакета (ни данных, ни pong на keepalive), сессия считается мёртвой и
+	// закрывается, чтобы воркер переподключился (новый TURN allocate + DTLS).
+	//
+	// Без этого после обрыва сети / смены Wi-Fi / сна ноутбука сессия висела
+	// «живой» до sessionReadTimeout (30 минут): UDP-запись в никуда не
+	// возвращает ошибку, а TURN-аллокация после смены NAT-маппинга мертва.
+	// Диспетчер продолжал раскидывать пакеты по зомби-воркерам → туннель
+	// не работал, хотя UI показывал «подключено».
+	sessionDeadAfter = 45 * time.Second
+
+	// configRequestAttempts — сколько раз одна сессия пробует GETCONF, прежде
+	// чем отдать право запроса другому воркеру.
+	configRequestAttempts = 3
 )
 
 // Handshake semaphore: limit to 3 concurrent DTLS handshakes
@@ -66,8 +81,24 @@ func RunSession(
 	creds *Credentials,
 	deviceID, password string,
 	stats *Stats,
+	onConfigAttempt func(delivered bool),
 ) (bool, error) {
 	configDelivered := false
+	// Сообщаем группе результат запроса конфига ровно один раз — либо сразу
+	// после попытки, либо (если до попытки не дошло) при выходе из сессии.
+	// Раньше флаг «запрос в полёте» сбрасывался только после смерти сессии,
+	// т.е. неудачный GETCONF первого воркера блокировал получение конфига
+	// на всё время жизни этой сессии (до 30 минут) — туннель «висел» на
+	// этапе WG.
+	configReported := false
+	reportConfig := func() {
+		if configReported || !getConfig || onConfigAttempt == nil {
+			return
+		}
+		configReported = true
+		onConfigAttempt(configDelivered)
+	}
+	defer reportConfig()
 
 	if len(creds.TurnURLs) == 0 {
 		return false, fmt.Errorf("нет TURN URL в учетных данных")
@@ -179,9 +210,7 @@ func RunSession(
 	getStreamCache(creds.CacheStreamID).errorCount.Store(0)
 
 	log.Printf("[СЕССИЯ #%d] Relay: %s", sessionID, relay.LocalAddr())
-	if EmitEvent != nil {
-		EmitEvent(Event{Type: EventEvent, Name: "turn_allocated", Data: fmt.Sprintf("session=%d", sessionID)})
-	}
+			emitEvent(Event{Type: EventEvent, Name: "turn_allocated", Data: fmt.Sprintf("session=%d", sessionID)})
 
 	// Pipe для DTLS ↔ TURN relay
 	pipeA, pipeB := connutil.AsyncPacketPipe()
@@ -334,57 +363,62 @@ func RunSession(
 			errStr := strings.ToLower(err.Error())
 			if strings.Contains(errStr, "deadline") || strings.Contains(errStr, "timeout") {
 				log.Printf("[ВОРКЕР #%d] [DTLS] Таймаут хендшейка (15s) с WRAP, пароль/WRAP не подтверждён", sessionID)
-				if EmitEvent != nil {
-					EmitEvent(Event{Type: EventEvent, Name: "wrap_auth_timeout", Data: fmt.Sprintf("worker=%d", sessionID)})
-				}
+									emitEvent(Event{Type: EventEvent, Name: "wrap_auth_timeout", Data: fmt.Sprintf("worker=%d", sessionID)})
 				return false, fmt.Errorf("WRAP_AUTH_TIMEOUT: DTLS timeout, пароль/WRAP не подтверждён")
 			}
 		}
-		if EmitEvent != nil {
-			EmitEvent(Event{Type: EventEvent, Name: "dtls_error", Data: fmt.Sprintf("worker=%d error=%s", sessionID, err.Error())})
-		}
+					emitEvent(Event{Type: EventEvent, Name: "dtls_error", Data: fmt.Sprintf("worker=%d error=%s", sessionID, err.Error())})
 		return false, fmt.Errorf("DTLS хендшейк: %w", err)
 	}
 	log.Printf("[ВОРКЕР #%d] [DTLS] Соединение установлено ✓", sessionID)
-	if EmitEvent != nil {
-		EmitEvent(Event{Type: EventEvent, Name: "dtls_ok", Data: fmt.Sprintf("worker=%d", sessionID)})
-	}
+			emitEvent(Event{Type: EventEvent, Name: "dtls_ok", Data: fmt.Sprintf("worker=%d", sessionID)})
 
 	// Emit ready event once the first worker completes DTLS handshake.
-	if EmitEvent != nil {
-		EmitEvent(Event{Type: EventEvent, Name: "ready", Data: fmt.Sprintf("worker=%d", sessionID)})
-	}
+			emitEvent(Event{Type: EventEvent, Name: "ready", Data: fmt.Sprintf("worker=%d", sessionID)})
 
 	atomic.AddInt32(&stats.ActiveConnections, 1)
 	defer atomic.AddInt32(&stats.ActiveConnections, -1)
 
-	// Запрос конфига
+	// Запрос конфига (несколько попыток внутри одной сессии: потеря одного
+	// UDP-пакета не должна стоить нам целой сессии).
 	if getConfig && configCh != nil {
-		conf, confErr := RequestConfig(dtlsConn, localPort, deviceID, password)
-		if confErr != nil {
-			errStr := confErr.Error()
-			if strings.Contains(errStr, "FATAL_AUTH") {
-				return false, confErr
+		for attempt := 1; attempt <= configRequestAttempts; attempt++ {
+			conf, confErr := RequestConfig(dtlsConn, localPort, deviceID, password)
+			if confErr != nil {
+				errStr := confErr.Error()
+				if strings.Contains(errStr, "FATAL_AUTH") {
+					return false, confErr
+				}
+				log.Printf("[ВОРКЕР #%d] Ошибка конфига (попытка %d/%d): %v", sessionID, attempt, configRequestAttempts, confErr)
+			} else if conf != "" {
+				select {
+				case configCh <- conf:
+					configDelivered = true
+					log.Printf("[ВОРКЕР #%d] Конфиг получен", sessionID)
+				default:
+					configDelivered = true
+					log.Printf("[ВОРКЕР #%d] Конфиг уже был доставлен другим воркером", sessionID)
+				}
+				break
+			} else {
+				log.Printf("[ВОРКЕР #%d] Сервер ещё не выдал WireGuard-конфиг (попытка %d/%d)", sessionID, attempt, configRequestAttempts)
 			}
-			log.Printf("[ВОРКЕР #%d] Ошибка конфига: %v", sessionID, confErr)
-		} else if conf != "" {
-			select {
-			case configCh <- conf:
-				configDelivered = true
-				log.Printf("[ВОРКЕР #%d] Конфиг получен", sessionID)
-			default:
-				configDelivered = true
-				log.Printf("[ВОРКЕР #%d] Конфиг уже был доставлен другим воркером", sessionID)
+			if attempt < configRequestAttempts {
+				select {
+				case <-time.After(2 * time.Second):
+				case <-sessCtx.Done():
+					return false, sessCtx.Err()
+				}
 			}
-		} else {
-			log.Printf("[ВОРКЕР #%d] Сервер ещё не выдал WireGuard-конфиг, повторим позже", sessionID)
+		}
+		reportConfig()
+		if !configDelivered {
+			log.Printf("[ВОРКЕР #%d] Конфиг не получен, право запроса передано другим воркерам", sessionID)
 		}
 	}
 
 	log.Printf("[ВОРКЕР #%d] [READY] Туннель готов к работе ✓", sessionID)
-	if EmitEvent != nil {
-		EmitEvent(Event{Type: EventEvent, Name: "worker_ready", Data: fmt.Sprintf("worker=%d", sessionID)})
-	}
+			emitEvent(Event{Type: EventEvent, Name: "worker_ready", Data: fmt.Sprintf("worker=%d", sessionID)})
 
 	// Регистрация в диспетчере
 	slot := &WorkerSlot{
@@ -403,7 +437,14 @@ func RunSession(
 	})
 	defer stopDTLS()
 
-	// DTLS Keepalive: prevents TURN allocation timeout and DTLS idle disconnect
+	// lastRx — unix-nano последнего пакета, полученного через DTLS (данные
+	// или pong). Обновляется Reader'ом, проверяется keepalive-горутиной.
+	var lastRx atomic.Int64
+	lastRx.Store(time.Now().UnixNano())
+
+	// DTLS Keepalive + liveness: шлём ping, и если ответов (или любых других
+	// пакетов) нет дольше sessionDeadAfter — закрываем сессию. Воркер
+	// переподключится с новой TURN-аллокацией.
 	go func() {
 		defer proxyWg.Done()
 		t := time.NewTicker(keepaliveInterval)
@@ -414,6 +455,13 @@ func RunSession(
 			case <-sessCtx.Done():
 				return
 			case <-t.C:
+				silent := time.Since(time.Unix(0, lastRx.Load()))
+				if silent > sessionDeadAfter {
+					log.Printf("[ВОРКЕР #%d] Нет ответа от сервера %.0fs — сессия мертва, переподключаемся", sessionID, silent.Seconds())
+					emitEvent(Event{Type: EventEvent, Name: "session_dead", Data: fmt.Sprintf("worker=%d silent=%.0fs", sessionID, silent.Seconds())})
+					sessCancel()
+					return
+				}
 				_ = dtlsConn.SetWriteDeadline(time.Now().Add(5 * time.Second))
 				if _, err := dtlsConn.Write(ping); err != nil {
 					log.Printf("[ВОРКЕР #%d] Keepalive write failed: %v, closing session", sessionID, err)
@@ -466,6 +514,8 @@ func RunSession(
 				log.Printf("[ВОРКЕР #%d] Ошибка Reader: %v", sessionID, readErr)
 				return
 			}
+
+			lastRx.Store(time.Now().UnixNano())
 
 			// Skip keepalive pong from server
 			if n == 1 && pkt[0] == keepaliveByte {

--- a/client/core/state.go
+++ b/client/core/state.go
@@ -47,9 +47,31 @@ func getCaptchaMode() string {
 // Хендлер должен вернуть success_token или ошибку.
 var WebViewCaptchaHandler func(mode, redirectURI, sessionToken string) (string, error)
 
-// EmitEvent — глобальный эмиттер событий, используется для captcha_required и т.п.
-// Устанавливается ядром при старте.
-var EmitEvent func(Event)
+// emitEventPtr — глобальный эмиттер событий (captcha_required, dtls_ok и т.п.).
+// Устанавливается ядром при старте через SetEmitEvent и сбрасывается при Stop.
+//
+// Хранится атомарно: раньше это была обычная переменная `EmitEvent`, и
+// паттерн `if EmitEvent != nil { EmitEvent(...) }` из воркер-горутин гонялся
+// с `EmitEvent = nil` в Core.Stop(). Между проверкой и вызовом переменная
+// успевала обнулиться → nil-func call → паника всего процесса. Теперь
+// указатель читается ровно один раз.
+var emitEventPtr atomic.Pointer[func(Event)]
+
+// SetEmitEvent устанавливает (или сбрасывает, если nil) глобальный эмиттер.
+func SetEmitEvent(f func(Event)) {
+	if f == nil {
+		emitEventPtr.Store(nil)
+		return
+	}
+	emitEventPtr.Store(&f)
+}
+
+// emitEvent безопасно вызывает текущий эмиттер (no-op, если он не задан).
+func emitEvent(ev Event) {
+	if p := emitEventPtr.Load(); p != nil {
+		(*p)(ev)
+	}
+}
 
 // drainCaptchaResult — выкидывает устаревший токен из канала, если там что-то есть.
 func drainCaptchaResult() {

--- a/client/core/turn_exclude.go
+++ b/client/core/turn_exclude.go
@@ -25,6 +25,9 @@ func AddTurnExcludeIP(ipStr string) {
 	}
 	turnExcludeIPs = append(turnExcludeIPs, ip)
 	log.Printf("[WG] TURN IP для исключения из WG: %s", ip)
+	// Если туннель уже поднят — маршрут нужен прямо сейчас, а не при
+	// следующем SetupWindowsWireGuard.
+	go applyTurnHostRoute(ip)
 }
 
 func getTurnExcludeIPs() []net.IP {

--- a/client/core/wg_other.go
+++ b/client/core/wg_other.go
@@ -3,6 +3,8 @@
 
 package core
 
+import "net"
+
 func SetupWindowsWireGuard(rawConf, ifaceName string, customDNS []string, excludeDomains []string) error {
 	return nil
 }
@@ -19,3 +21,6 @@ func runRouteAdd(cidr, gateway string) bool {
 
 func runRouteDelete(cidr string) {}
 
+
+// applyTurnHostRoute — no-op на не-Windows платформах.
+func applyTurnHostRoute(ip net.IP) {}

--- a/client/core/wg_route_guard_windows.go
+++ b/client/core/wg_route_guard_windows.go
@@ -1,0 +1,297 @@
+//go:build windows
+// +build windows
+
+package core
+
+import (
+	"fmt"
+	"log"
+	"net"
+	"sync"
+	"time"
+	"unsafe"
+
+	"golang.org/x/sys/windows"
+)
+
+// Route guard — страховка маршрутов-исключений при смене сети.
+//
+// Проблема: SetupWindowsWireGuard один раз определяет «физический» шлюз и
+// вешает на него /32-маршруты к TURN-серверам, VK CIDR и подмену DNS.
+// Если пользователь переключился с Wi-Fi на Ethernet, сменил точку доступа,
+// вернулся из сна с другим DHCP-шлюзом или интерфейс просто моргнул (Windows
+// при down/up сносит маршруты этого интерфейса) — исключения указывают в
+// пустоту, трафик к TURN уходит в WG default route (0.0.0.0/0), а WG шлёт его
+// обратно в диспетчер → воркеры никогда не переподключатся.
+//
+// Решение: пока туннель поднят, каждые routeGuardInterval опрашиваем таблицу
+// адаптеров (GetAdaptersAddresses — без запуска процессов) и, если шлюз/
+// интерфейс сменился или снова появился после пропажи, переставляем все
+// исключения на актуальный шлюз.
+
+const routeGuardInterval = 3 * time.Second
+
+// wgRuntime — состояние поднятого туннеля, нужное route guard'у.
+type wgRuntime struct {
+	mu          sync.Mutex
+	ifaceName   string          // имя WG-адаптера (исключается из поиска шлюза)
+	gateway     string          // текущий физический шлюз ("" = не найден)
+	iface       string          // интерфейс физического шлюза
+	turnRoutes  map[string]bool // TURN IP → /32 добавлен через текущий шлюз
+	dnsOverride bool            // подменяем ли системный DNS на 127.0.0.1
+	stop        chan struct{}
+	done        chan struct{}
+}
+
+var (
+	activeWGMu sync.Mutex
+	activeWG   *wgRuntime
+)
+
+// detectPhysicalGateway возвращает IPv4-шлюз по умолчанию и имя интерфейса,
+// пропуская наш WG-адаптер, loopback и адаптеры без реального next-hop.
+// При нескольких кандидатах берётся интерфейс с наименьшей метрикой.
+func detectPhysicalGateway(excludeIface string) (gateway, ifaceName string) {
+	const flags = windows.GAA_FLAG_INCLUDE_GATEWAYS |
+		windows.GAA_FLAG_SKIP_ANYCAST |
+		windows.GAA_FLAG_SKIP_MULTICAST |
+		windows.GAA_FLAG_SKIP_DNS_SERVER
+
+	size := uint32(16 * 1024)
+	var buf []byte
+	for attempt := 0; attempt < 4; attempt++ {
+		buf = make([]byte, size)
+		err := windows.GetAdaptersAddresses(windows.AF_INET, flags, 0,
+			(*windows.IpAdapterAddresses)(unsafe.Pointer(&buf[0])), &size)
+		if err == nil {
+			break
+		}
+		if err != windows.ERROR_BUFFER_OVERFLOW {
+			return "", ""
+		}
+	}
+	if len(buf) == 0 {
+		return "", ""
+	}
+
+	bestMetric := ^uint32(0)
+	for a := (*windows.IpAdapterAddresses)(unsafe.Pointer(&buf[0])); a != nil; a = a.Next {
+		if a.OperStatus != windows.IfOperStatusUp {
+			continue
+		}
+		if a.IfType == windows.IF_TYPE_SOFTWARE_LOOPBACK {
+			continue
+		}
+		name := windows.UTF16PtrToString(a.FriendlyName)
+		if name == "" || name == excludeIface {
+			continue
+		}
+		if a.FirstUnicastAddress == nil {
+			continue
+		}
+		var gw string
+		for g := a.FirstGatewayAddress; g != nil; g = g.Next {
+			ip := g.Address.IP()
+			if ip == nil || ip.IsUnspecified() || ip.To4() == nil {
+				continue
+			}
+			gw = ip.String()
+			break
+		}
+		if gw == "" {
+			continue
+		}
+		if a.Ipv4Metric < bestMetric {
+			bestMetric = a.Ipv4Metric
+			gateway, ifaceName = gw, name
+		}
+	}
+	return gateway, ifaceName
+}
+
+// startRouteGuard запускает мониторинг после успешного поднятия WG.
+func startRouteGuard(rt *wgRuntime) {
+	activeWGMu.Lock()
+	activeWG = rt
+	activeWGMu.Unlock()
+	rt.stop = make(chan struct{})
+	rt.done = make(chan struct{})
+	go rt.loop()
+}
+
+// stopRouteGuard останавливает мониторинг (вызывается из teardown).
+func stopRouteGuard() {
+	activeWGMu.Lock()
+	rt := activeWG
+	activeWG = nil
+	activeWGMu.Unlock()
+	if rt == nil {
+		return
+	}
+	close(rt.stop)
+	<-rt.done
+}
+
+func (rt *wgRuntime) loop() {
+	defer close(rt.done)
+	t := time.NewTicker(routeGuardInterval)
+	defer t.Stop()
+	warnedAbsent := false
+	for {
+		select {
+		case <-rt.stop:
+			return
+		case <-t.C:
+		}
+
+		gw, iface := detectPhysicalGateway(rt.ifaceName)
+
+		rt.mu.Lock()
+		curGw, curIface := rt.gateway, rt.iface
+		rt.mu.Unlock()
+
+		if gw == "" {
+			if curGw != "" {
+				log.Printf("[ROUTE-GUARD] Физический шлюз пропал (%s via %s) — ждём сеть", curGw, curIface)
+				rt.mu.Lock()
+				rt.gateway, rt.iface = "", ""
+				rt.mu.Unlock()
+				warnedAbsent = true
+			}
+			continue
+		}
+		if gw == curGw && iface == curIface {
+			continue
+		}
+
+		if curGw == "" && !warnedAbsent {
+			log.Printf("[ROUTE-GUARD] Найден физический шлюз: %s via %s", gw, iface)
+		} else {
+			log.Printf("[ROUTE-GUARD] Смена сети: %s via %q → %s via %q, переставляем исключения",
+				curGw, curIface, gw, iface)
+		}
+		warnedAbsent = false
+		rt.switchGateway(curIface, gw, iface)
+	}
+}
+
+// switchGateway снимает исключения со старого интерфейса и ставит на новый.
+func (rt *wgRuntime) switchGateway(oldIface, gw, iface string) {
+	rt.removeTurnRoutes(oldIface)
+	removeExcludeRoutes()
+
+	rt.mu.Lock()
+	rt.gateway, rt.iface = gw, iface
+	rt.mu.Unlock()
+
+	rt.applyTurnRoutes()
+	applyExcludeRoutes(gw, iface)
+
+	if rt.dnsOverride {
+		overrideInterfaceDNS(iface)
+		_ = hiddenCmd("ipconfig", "/flushdns").Run()
+	}
+
+	dnsProxyMu.Lock()
+	de := activeDomainExcluder
+	dnsProxyMu.Unlock()
+	if de != nil {
+		de.SetGateway(gw, iface)
+	}
+	emitEvent(Event{Type: EventEvent, Name: "route_guard_switch", Data: fmt.Sprintf("gw=%s iface=%s", gw, iface)})
+}
+
+// applyTurnRoutes добавляет /32 на все известные TURN IP через текущий шлюз.
+func (rt *wgRuntime) applyTurnRoutes() {
+	rt.mu.Lock()
+	gw, iface := rt.gateway, rt.iface
+	rt.mu.Unlock()
+	if gw == "" || iface == "" {
+		return
+	}
+	added := 0
+	for _, ip := range getTurnExcludeIPs() {
+		if rt.addTurnRoute(ip, gw, iface) {
+			added++
+		}
+	}
+	if added > 0 {
+		log.Printf("[ROUTE-GUARD] TURN-исключений через %s (%s): %d", gw, iface, added)
+	}
+}
+
+func (rt *wgRuntime) addTurnRoute(ip net.IP, gw, iface string) bool {
+	key := ip.String()
+	rt.mu.Lock()
+	if rt.turnRoutes[key] {
+		rt.mu.Unlock()
+		return false
+	}
+	rt.mu.Unlock()
+	if err := addHostRoute(iface, gw, key); err != nil {
+		log.Printf("[WG] Не удалось добавить TURN-исключение %s: %v", key, err)
+		return false
+	}
+	rt.mu.Lock()
+	rt.turnRoutes[key] = true
+	rt.mu.Unlock()
+	return true
+}
+
+// removeTurnRoutes удаляет ранее добавленные /32 TURN-маршруты.
+func (rt *wgRuntime) removeTurnRoutes(iface string) {
+	rt.mu.Lock()
+	keys := make([]string, 0, len(rt.turnRoutes))
+	for k := range rt.turnRoutes {
+		keys = append(keys, k)
+	}
+	rt.turnRoutes = make(map[string]bool)
+	rt.mu.Unlock()
+	for _, k := range keys {
+		if iface != "" {
+			_ = runNetsh("interface", "ipv4", "delete", "route", k+"/32", iface, "store=active")
+		}
+		runRouteDelete(k)
+	}
+}
+
+// applyTurnHostRoute вызывается из AddTurnExcludeIP: если туннель уже поднят,
+// новый TURN IP (например, после обновления кредов) сразу выводится из-под WG.
+func applyTurnHostRoute(ip net.IP) {
+	activeWGMu.Lock()
+	rt := activeWG
+	activeWGMu.Unlock()
+	if rt == nil {
+		return
+	}
+	rt.mu.Lock()
+	gw, iface := rt.gateway, rt.iface
+	rt.mu.Unlock()
+	if gw == "" || iface == "" {
+		return
+	}
+	if rt.addTurnRoute(ip, gw, iface) {
+		log.Printf("[ROUTE-GUARD] Новый TURN IP %s → /32 через %s (%s)", ip, gw, iface)
+	}
+}
+
+// overrideInterfaceDNS подменяет DNS интерфейса на 127.0.0.1, запоминая
+// оригинал для восстановления в teardown. Повторный вызов для того же
+// интерфейса — no-op.
+func overrideInterfaceDNS(iface string) {
+	if iface == "" {
+		return
+	}
+	dnsProxyMu.Lock()
+	defer dnsProxyMu.Unlock()
+	if _, done := originalDNSByIf[iface]; done {
+		return
+	}
+	orig := getInterfaceDNS(iface)
+	originalDNSByIf[iface] = orig
+	if err := setInterfaceDNS(iface, []string{"127.0.0.1"}); err != nil {
+		log.Printf("[DNS] Не удалось подменить системный DNS на %s: %v", iface, err)
+		return
+	}
+	log.Printf("[DNS] Системный DNS %s: %v → 127.0.0.1 (через локальный прокси)", iface, orig)
+}

--- a/client/core/wg_windows.go
+++ b/client/core/wg_windows.go
@@ -192,8 +192,13 @@ func SetupWindowsWireGuard(rawConf, ifaceName string, customDNS []string, exclud
 		}
 	}
 
-	// Запоминаем оригинальный шлюз ДО того, как WG перехватит маршрутизацию
-	origGateway, origIface := getDefaultGateway()
+	// Запоминаем оригинальный шлюз ДО того, как WG перехватит маршрутизацию.
+	// Сначала быстрый путь через GetAdaptersAddresses (без PowerShell), он же
+	// используется route guard'ом; PowerShell/route print — fallback.
+	origGateway, origIface := detectPhysicalGateway(actualName)
+	if origGateway == "" || origIface == "" {
+		origGateway, origIface = getDefaultGateway()
+	}
 	if origGateway == "" && origIface != "" {
 		origGateway = getInterfaceGateway(origIface)
 	}
@@ -213,15 +218,20 @@ func SetupWindowsWireGuard(rawConf, ifaceName string, customDNS []string, exclud
 
 	// TURN-исключения: добавляем /32 маршруты на TURN-сервера через оригинальный шлюз.
 	// Это критично — без них WG-default route 0.0.0.0/0 перехватит трафик к TURN,
-	// и туннель упадёт в первую же секунду.
+	// и туннель упадёт в первую же секунду. Состояние живёт в wgRuntime, чтобы
+	// route guard мог переставить маршруты при смене сети, а AddTurnExcludeIP —
+	// добавить новые TURN IP на лету.
+	rt := &wgRuntime{
+		ifaceName:   actualName,
+		gateway:     origGateway,
+		iface:       origIface,
+		turnRoutes:  make(map[string]bool),
+		dnsOverride: len(customDNS) > 0,
+	}
 	if origGateway != "" && origIface != "" {
-		for _, ip := range getTurnExcludeIPs() {
-			if err := addHostRoute(origIface, origGateway, ip.String()); err != nil {
-				log.Printf("[WG] Не удалось добавить TURN-исключение %s: %v", ip, err)
-			}
-		}
+		rt.applyTurnRoutes()
 	} else {
-		log.Printf("[WG] ⚠ TURN-исключения НЕ добавлены — туннель может быть нестабильным")
+		log.Printf("[WG] ⚠ TURN-исключения НЕ добавлены — туннель может быть нестабильным (route guard добавит их, когда появится шлюз)")
 	}
 
 	// VK CIDR + DNS-исключения: используем route add (более простой, чем netsh).
@@ -280,6 +290,9 @@ func SetupWindowsWireGuard(rawConf, ifaceName string, customDNS []string, exclud
 		wgTeardownMu.Unlock()
 
 		log.Printf("[WG] Teardown интерфейса %s...", actualName)
+		// Останавливаем route guard, чтобы он не переставлял маршруты
+		// параллельно с их удалением.
+		stopRouteGuard()
 		// Сначала останавливаем DNS-прокси и возвращаем оригинальный DNS,
 		// чтобы приложения не потеряли резолв после удаления туннеля.
 		dnsProxyMu.Lock()
@@ -309,6 +322,10 @@ func SetupWindowsWireGuard(rawConf, ifaceName string, customDNS []string, exclud
 		// Сначала убираем exclude-маршруты, чтобы вернуть трафик в норму,
 		// даже если удаление TUN/default route по какой-то причине отвалится.
 		removeExcludeRoutes()
+		rt.mu.Lock()
+		turnIface := rt.iface
+		rt.mu.Unlock()
+		rt.removeTurnRoutes(turnIface)
 		_ = runNetsh("interface", "ipv4", "delete", "route", "0.0.0.0/0", actualName, "0.0.0.0", "store=active")
 		_ = runNetsh("interface", "ipv4", "delete", "address", fmt.Sprintf("name=%s", actualName), fmt.Sprintf("address=%s", cfg.address), "store=active")
 		log.Printf("[WG] Teardown завершён")
@@ -361,15 +378,7 @@ func SetupWindowsWireGuard(rawConf, ifaceName string, customDNS []string, exclud
 				log.Printf("[DOMEXCL] Доменные исключения не активированы (gateway=%q, dns=%v)", origGateway, customDNS)
 			}
 
-			if origIface != "" {
-				orig := getInterfaceDNS(origIface)
-				originalDNSByIf[origIface] = orig
-				if err := setInterfaceDNS(origIface, []string{"127.0.0.1"}); err != nil {
-					log.Printf("[DNS] Не удалось подменить системный DNS на %s: %v", origIface, err)
-				} else {
-					log.Printf("[DNS] Системный DNS %s: %v → 127.0.0.1 (через локальный прокси)", origIface, orig)
-				}
-			}
+			overrideInterfaceDNS(origIface)
 			// Сбрасываем кэш, чтобы новые запросы пошли сразу через прокси.
 			_ = hiddenCmd("ipconfig", "/flushdns").Run()
 		}
@@ -379,6 +388,9 @@ func SetupWindowsWireGuard(rawConf, ifaceName string, customDNS []string, exclud
 		<-wgDev.Wait()
 		log.Printf("[WG] WireGuard устройство %s остановлено", actualName)
 	}()
+
+	// Мониторим смену физического шлюза/интерфейса и переставляем исключения.
+	startRouteGuard(rt)
 
 	return nil
 }

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -51,6 +51,7 @@ function useWailsEvents() {
         const s = String(status ?? '');
         if (s === 'running') { tunnelStore.set('connected'); logStore.push('INFO', '✓ Туннель активен'); }
         else if (s === 'connecting') { tunnelStore.set('connecting'); logStore.push('INFO', '⟳ Подключение...'); }
+        else if (s === 'reconnecting') { tunnelStore.set('reconnecting'); logStore.push('WARN', '⟳ Обрыв — переподключение...'); pipelineStore.hide(); }
         else if (s === 'stopped' || s === 'error' || s === 'disconnected') { tunnelStore.set('idle'); logStore.push('INFO', '— Отключено'); pipelineStore.hide(); }
       }),
       EventsOn('pipeline_state', (payload: unknown) => {

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -41,9 +41,10 @@ export interface AppSettings {
 
   closeAction: CloseAction;     // действие при нажатии X (default 'ask' = показать диалог)
   obfsMode: ObfsMode;           // режим маскировки RTP: audio (OPUS/PT111) или video (H264/PT96)
+  autoReconnect: boolean;       // автоматически переподключаться после обрыва (default true)
 }
 
-export type TunnelState = 'idle' | 'connecting' | 'connected' | 'disconnecting';
+export type TunnelState = 'idle' | 'connecting' | 'reconnecting' | 'connected' | 'disconnecting';
 
 export interface Subscription {
   id: string;
@@ -96,6 +97,7 @@ export const DEFAULT_SETTINGS: AppSettings = {
   wgInterface: 'WDTT',
   closeAction: 'ask',
   obfsMode: 'audio',
+  autoReconnect: true,
 };
 
 export const DNS_PRESETS: Record<Exclude<DnsProvider, 'custom'>, { name: string; servers: string }> = {

--- a/frontend/src/pages/Exclusions.tsx
+++ b/frontend/src/pages/Exclusions.tsx
@@ -82,7 +82,7 @@ export default function Exclusions() {
     }
   };
 
-  const tunnelRunning = tunnelState === 'connected' || tunnelState === 'connecting';
+  const tunnelRunning = tunnelState === 'connected' || tunnelState === 'connecting' || tunnelState === 'reconnecting';
 
   return (
     <>

--- a/frontend/src/pages/Info.tsx
+++ b/frontend/src/pages/Info.tsx
@@ -110,7 +110,7 @@ export default function Info() {
             </span>
             <span className="if-value" style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
               <span className={`if-status-dot ${running ? 'if-status-dot--on' : 'if-status-dot--off'}`} />
-              {running ? 'Активен' : tunnelState === 'connecting' ? 'Подключение' : 'Не запущен'}
+              {running ? 'Активен' : tunnelState === 'connecting' ? 'Подключение' : tunnelState === 'reconnecting' ? 'Переподключение' : 'Не запущен'}
             </span>
           </div>
           <div className="if-row">

--- a/frontend/src/pages/Settings.tsx
+++ b/frontend/src/pages/Settings.tsx
@@ -63,7 +63,7 @@ export default function Settings() {
     }
   };
 
-  const locked = tunnelState === 'connected' || tunnelState === 'connecting';
+  const locked = tunnelState === 'connected' || tunnelState === 'connecting' || tunnelState === 'reconnecting';
 
   const update = <K extends keyof AppSettings>(key: K, value: AppSettings[K]) => {
     setSettings(s => {
@@ -294,6 +294,20 @@ export default function Settings() {
             <button
               className={`sp-toggle${settings.autoWG ? ' sp-toggle--on' : ''}`}
               onClick={() => update('autoWG', !settings.autoWG)}
+            />
+          </div>
+
+          <div className="sp-row">
+            <span className="sp-label">
+              <span className="sp-label-main">
+                <IconRotate size={16} />
+                Автопереподключение
+              </span>
+              <span className="sp-label-sub">поднимать туннель заново после обрыва</span>
+            </span>
+            <button
+              className={`sp-toggle${settings.autoReconnect !== false ? ' sp-toggle--on' : ''}`}
+              onClick={() => update('autoReconnect', settings.autoReconnect === false)}
             />
           </div>
 

--- a/frontend/src/pages/Tunnel.tsx
+++ b/frontend/src/pages/Tunnel.tsx
@@ -37,6 +37,7 @@ import { resolveDnsUpstream } from '../lib/types';
 const TUNNEL_LABEL: Record<TunnelState, string> = {
   idle: 'Отключено',
   connecting: 'Подключение…',
+  reconnecting: 'Переподключение…',
   connected: 'Подключено',
   disconnecting: 'Отключение…',
 };
@@ -237,6 +238,7 @@ export default function Tunnel() {
         dnsUpstream: dnsUpstream.length > 0 ? dnsUpstream : undefined,
         wgInterface: s.wgInterface || 'WDTT',
         excludeDomains: excludeDomains.length > 0 ? excludeDomains : undefined,
+        autoReconnect: s.autoReconnect !== false,
       };
       if (cur.subscriptionId) {
         // For subscription profiles pass runtime data so the backend does not
@@ -269,7 +271,7 @@ export default function Tunnel() {
       }
       toastStore.show('Запускаю туннель', 2000);
       await doConnect();
-    } else if (tunnelStateRef.current === 'connected' || tunnelStateRef.current === 'connecting') {
+    } else if (tunnelStateRef.current === 'connected' || tunnelStateRef.current === 'connecting' || tunnelStateRef.current === 'reconnecting') {
       tunnelStore.set('disconnecting');
       try {
         await WailsDisconnect();
@@ -608,13 +610,13 @@ export default function Tunnel() {
             Секреты
           </button>
           <button
-            className={`tn-action ${tunnelState === 'connected' || tunnelState === 'connecting' ? 'tn-action--danger' : 'tn-action--filled'}`}
+            className={`tn-action ${tunnelState === 'connected' || tunnelState === 'connecting' || tunnelState === 'reconnecting' ? 'tn-action--danger' : 'tn-action--filled'}`}
             onClick={handleConnect}
           >
-            {tunnelState === 'connected' || tunnelState === 'connecting' ? (
+            {tunnelState === 'connected' || tunnelState === 'connecting' || tunnelState === 'reconnecting' ? (
               <>
                 <IconPlayerStopFilled size={18} />
-                {tunnelState === 'connected' ? 'Отключить' : 'Подключение…'}
+                {tunnelState === 'connected' ? 'Отключить' : TUNNEL_LABEL[tunnelState]}
               </>
             ) : (
               <>


### PR DESCRIPTION
Клиент рушился при любом обрыве сети. Пять причин, все исправлены:

1. **Pipeline-контроллер** сносил рабочий туннель по `dtls_error`/`wrap_auth_timeout` любого воркера (в т.ч. при штатном переподключении). Теперь после `wg_up` инертен; до первого успеха DTLS терпит один провал; таймауты TURN/DTLS 40с.
2. **Мёртвые сессии не обнаруживались** до 30-минутного read timeout (UDP-запись не даёт ошибки, pion/turn при провале refresh только логирует). Добавлен liveness: ping 10с, 45с тишины → сессия закрывается, воркер переподключается.
3. **Маршруты-исключения не переживали смену сети** (TURN /32, VK CIDR, DNS). Route guard на `GetAdaptersAddresses` переставляет их при смене шлюза/интерфейса. Новые TURN IP после обновления кредов исключаются сразу.
4. **Гонка на `EmitEvent`** между воркерами и `Core.Stop` → nil-func panic всего процесса. Атомарный указатель; закрыт `send on closed channel` в `Core.emit`.
5. Парсинг TURN URL (`TrimPrefix("turn://")` для `turn:IP:PORT`) — per-IP исключения не добавлялись вообще. `error 29`/`cannot create socket` навсегда убивали воркер. Неудачный GETCONF блокировал конфиг на всю жизнь сессии.

Страховка: автопереподключение с backoff 3с→60с, если ядро завершилось само (не по кнопке, не из-за пароля). Переключатель в настройках, по умолчанию вкл.

Собирается (`wails build`, tsc чистый). Живой туннель протестирован — всё работает.